### PR TITLE
Replace mock release in the CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,35 +14,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-#      - name: Install protoc
-#        id: deps-protoc
-#        shell: bash
-#        run: |
-#          curl -Lo /tmp/protoc.zip \
-#          "https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-linux-x86_64.zip"
-#          unzip -o /tmp/protoc.zip -d ${HOME}/.local
-#          echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
-#          export PATH="${PATH}:${HOME}/.local/bin"
-#
-#      - name: Add Rust targets
-#        run: rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
-#
-#      - name: Build for Linux x86
-#        run: cargo build -r --target=x86_64-unknown-linux-gnu --verbose && mv target/aarch64-apple-darwin/platform-cli ./platform-cli_x86_64-gnu
-#
-#      - name: Build for Linux arm64
-#        run: cargo build -r --target=aarch64-unknown-linux-gnu --verbose && mv target/aarch64-unknown-linux-gnu/platform-cli ./platform-cli-arm64-gnu
-#
-#      - name: Build for Apple x86
-#        run: cargo build -r --target=x86_64-apple-darwin --verbose && mv target/x86_64-apple-darwin/platform-cli ./platform-cli_x86_64-darwin
-#
-#      - name: Build for Apple Silicon
-#        run: cargo build -r --target=aarch64-apple-darwin --verbose && mv target/aarch64-apple-darwin/platform-cli ./platform-cli_arm64-darwin
+      - name: Install protoc
+        id: deps-protoc
+        shell: bash
+        run: |
+          curl -Lo /tmp/protoc.zip \
+          "https://github.com/protocolbuffers/protobuf/releases/download/v27.3/protoc-27.3-linux-x86_64.zip"
+          unzip -o /tmp/protoc.zip -d ${HOME}/.local
+          echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
+          export PATH="${PATH}:${HOME}/.local/bin"
+
+      - name: Add Rust targets
+        run: rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-apple-darwin aarch64-apple-darwin
+
+      - name: Build for Linux x86
+        run: cargo build -r --target=x86_64-unknown-linux-gnu --verbose && mv target/aarch64-apple-darwin/platform-cli ./platform-cli_gnu-x86_64
+
+      - name: Build for Linux arm64
+        run: cargo build -r --target=aarch64-unknown-linux-gnu --verbose && mv target/aarch64-unknown-linux-gnu/platform-cli ./platform-cli-gnu-arm64
+
+      - name: Build for Apple x86
+        run: cargo build -r --target=x86_64-apple-darwin --verbose && mv target/x86_64-apple-darwin/platform-cli ./platform-cli_darwin-x86_64
 
       - name: Build for Apple Silicon
-        run: echo sampletext >  asset.txt
+        run: cargo build -r --target=aarch64-apple-darwin --verbose && mv target/aarch64-apple-darwin/platform-cli ./platform-cli_darwin-arm64
 
       - uses: softprops/action-gh-release@v2
         with:
           files: |
-            asset.txt
+            platform-cli_gnu-x86_64
+            platform-cli-gnu-arm64
+            platform-cli_darwin-x86_64
+            platform-cli_darwin-arm64


### PR DESCRIPTION
# Issue

For testing, I prepared a workflow definition, but used mock files for testing. Now I'm replacing with production

# Things done

* Updated Github Actions release.yml