### PR TITLE
Downgrade Linux GLIBC requirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-i386
-
+        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm gcc-aarch64-linux-gnu
       - name: Install protoc
         id: deps-protoc
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-i386 g++-13-multilib gcc-13-multilib && dpkg -l
+        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-i386
 
       - name: Install protoc
         id: deps-protoc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,12 @@ on:
 
 jobs:
   test:
-    name: Build Linux (arm64)
+    name: Build
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm gcc-aarch64-linux-gnu
       - name: Install protoc
         id: deps-protoc
         shell: bash
@@ -26,16 +24,5 @@ jobs:
           echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
           export PATH="${PATH}:${HOME}/.local/bin"
 
-      - name: Add Rust targets
-        run: rustup target add aarch64-unknown-linux-gnu
-
-      - name: Create Cargo multiarch config
-        run: |
-          touch ~/.cargo/config.toml
-          echo "
-          [target.aarch64-unknown-linux-gnu]
-          linker = \"aarch64-linux-gnu-gcc\"
-          " > ~/.cargo/config.toml
-
-      - name: Build for Linux arm64
-        run: cargo build -r --target=aarch64-unknown-linux-gnu && mv target/aarch64-unknown-linux-gnu/release/platform-cli ./platform-cli-gnu-arm64
+      - name: Build
+        run: cargo build -r

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   test:
-    name: Build
-    runs-on: ubuntu-22.04
+    name: Build Linux (arm64)
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-i386 g++-13-multilib gcc-13-multilib && dpkg -l
 
       - name: Install protoc
         id: deps-protoc
@@ -24,5 +27,16 @@ jobs:
           echo "PROTOC=${HOME}/.local/bin/protoc" >> $GITHUB_ENV
           export PATH="${PATH}:${HOME}/.local/bin"
 
-      - name: Build
-        run: cargo build -r
+      - name: Add Rust targets
+        run: rustup target add aarch64-unknown-linux-gnu
+
+      - name: Create Cargo multiarch config
+        run: |
+          touch ~/.cargo/config.toml
+          echo "
+          [target.aarch64-unknown-linux-gnu]
+          linker = \"aarch64-linux-gnu-gcc\"
+          " > ~/.cargo/config.toml
+
+      - name: Build for Linux arm64
+        run: cargo build -r --target=aarch64-unknown-linux-gnu && mv target/aarch64-unknown-linux-gnu/release/platform-cli ./platform-cli-gnu-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_linux_x86_64:
     name: Build Linux (x86_64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -40,13 +40,13 @@ jobs:
 
   build_linux_arm64:
     name: Build Linux (arm64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm g++-aarch64-linux-gnu gcc-aarch64-linux-gnu libc6-dev-i386 g++-13-multilib gcc-13-multilib && dpkg -l
+        run: sudo apt-get install -y build-essential pkg-config libssl-dev clang cmake llvm gcc-aarch64-linux-gnu
 
       - name: Install protoc
         id: deps-protoc


### PR DESCRIPTION
# Issue
Linux binaries is being built with Ubuntu 24.04 on a CI which has more recent glibc version, leading to this error when user execute a binary:

```
./platform-cli-gnu-arm64: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by ./platform-cli-gnu-arm64) 
```

The project has to be built on minimum OS version possible to ensure backward compatibility on older clients

# Things done
* Downgraded Linux runners to Ubuntu 20.04
* Removed some unnecessary system requirements