### PR TITLE
Strip input file whitespaces and newlines

### DIFF
--- a/src/commands/masternode_vote_dpns_name.rs
+++ b/src/commands/masternode_vote_dpns_name.rs
@@ -30,7 +30,7 @@ pub struct MasternodeVoteDPNSNameCommand {
     #[clap(long, default_value(""))]
     pro_tx_hash: String,
 
-    /// Voting (or Owner) private key in WIF format
+    /// Path to file with voting (or owner) private key in WIF format
     #[clap(long, default_value(""))]
     private_key: String,
 
@@ -67,7 +67,8 @@ impl MasternodeVoteDPNSNameCommand {
         let secp = Secp256k1::new();
 
         let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read file");
-        let private_key = PrivateKey::from_wif(&private_key_data).expect("Could not load private key from WIF");
+        let (private_key_data_stripped, _) = private_key_data.split_at(52);
+        let private_key = PrivateKey::from_wif(&private_key_data_stripped).expect("Could not load private key from WIF");
         let public_key = private_key.public_key(&secp);
         let pro_tx_hash = ProTxHash::from_hex(&self.pro_tx_hash).expect("Could not decode pro tx hash");
         let voting_address = public_key.pubkey_hash().to_byte_array();

--- a/src/commands/register_dpns_name.rs
+++ b/src/commands/register_dpns_name.rs
@@ -48,7 +48,7 @@ pub struct RegisterDPNSNameCommand {
     #[clap(long, default_value(""))]
     identity: String,
 
-    /// Identity private key in WIF format
+    /// Path to file with private key from Identity in WIF format
     #[clap(long, default_value(""))]
     private_key: String,
 
@@ -78,7 +78,8 @@ impl RegisterDPNSNameCommand {
         let secp = Secp256k1::new();
 
         let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read file");
-        let private_key = PrivateKey::from_wif(&private_key_data).expect("Could not load private key from WIF");
+        let (private_key_data_stripped, _) = private_key_data.split_at(52);
+        let private_key = PrivateKey::from_wif(&private_key_data_stripped).expect("Could not load private key from WIF");
         let public_key = private_key.public_key(&secp);
         let identifier = Identifier::from_string(&self.identity, Base58).unwrap();
 

--- a/src/commands/withdraw.rs
+++ b/src/commands/withdraw.rs
@@ -27,15 +27,19 @@ pub struct WithdrawCommand {
     /// DAPI GRPC Endpoint URL, ex. https://127.0.0.1:1443
     #[clap(long, default_value(""))]
     dapi_url: String,
+
     /// Identity address, that initiate withdrawal
     #[clap(long, default_value(""))]
     identity: String,
-    /// Identity private key in WIF format
+
+    /// Path to file with private key from Identity in WIF format
     #[clap(long, default_value(""))]
     private_key: String,
+
     /// Core withdrawal address (P2PKH / P2SH)
     #[clap(long, default_value(""))]
     withdrawal_address: String,
+
     /// Amount of credits to withdraw
     #[clap(long, default_value(""))]
     amount: String,
@@ -65,8 +69,9 @@ impl WithdrawCommand {
 
         let secp = Secp256k1::new();
 
-        let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read file");
-        let private_key = PrivateKey::from_wif(&private_key_data).expect("Could not load private key from WIF");
+        let private_key_data = fs::read_to_string(&self.private_key.trim()).expect("Unable to read file");
+        let (private_key_data_stripped, _) = private_key_data.split_at(52);
+        let private_key = PrivateKey::from_wif(&private_key_data_stripped).expect("Could not load private key from WIF");
         let public_key = private_key.public_key(&secp);
 
         let platform_grpc_client = PlatformGRPCClient::new(&self.dapi_url);


### PR DESCRIPTION
# Issue

Application takes file path of your private key as a command flag, but it does not sanitize whitespaces and newlines, leading to error if your file contains special characters:

```
thread 'main' panicked at src/commands/register_dpns_name.rs:82:67:
Could not load private key from WIF: Base58(BadByte(10))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Input data should be sanitized before passing down

# Things done

* Added stripping everything over 52 characters for input key data file (wif is 52 chars length) as a temporary solution