### PR TITLE
Accept all possible private key encoding types (base64, hex, wif)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ You can use --help to get more info about command flags
 
 Example commands:
 ```bash
-$ platform-cli withdraw --dapi-url https://127.0.0.1:1443 --identity A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb --private-key private_key.txt --withdrawal-address yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk --amount 40000
-$ platform-cli register-dpns-name --identity 8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc --private-key private_key.txt --dapi-url https://52.43.13.92:1443 --name tesstst32423sts
-$ platform-cli masternode-vote-dpns-name --dapi-url https://52.43.13.92:1443 --private-key voting_key.txt --pro-tx-hash 7a1ae04de7582262d9dea3f4d72bc24a474c6f71988066b74a41f17be5552652 --normalized-label testc0ntested --choice 8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc
+$ platform-cli withdraw --network testnet --dapi-url https://127.0.0.1:1443 --identity A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb --private-key private_key.txt --withdrawal-address yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk --amount 40000
+$ platform-cli register-dpns-name --network testnet --dapi-url https://52.43.13.92:1443 --identity 8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc --private-key private_key.txt --name tesstst32423sts
+$ platform-cli masternode-vote-dpns-name --network testnet --dapi-url https://52.43.13.92:1443 --private-key voting_key.txt --pro-tx-hash 7a1ae04de7582262d9dea3f4d72bc24a474c6f71988066b74a41f17be5552652 --normalized-label testc0ntested --choice 8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc
 ```
 
 ### Credits Withdrawal
@@ -54,12 +54,14 @@ Withdraw credits from the Identity to the L1 Core chain
 Usage: platform-cli withdraw [OPTIONS]
 
 Options:
+      --network <NETWORK>
+          Network, mainnet or testnet [default: ]
       --dapi-url <DAPI_URL>
           DAPI GRPC Endpoint URL, ex. https://127.0.0.1:1443 [default: ]
       --identity <IDENTITY>
           Identity address, that initiate withdrawal [default: ]
       --private-key <PRIVATE_KEY>
-          Identity private key in WIF format [default: ]
+          Path to file with private key from Identity in WIF format [default: ]
       --withdrawal-address <WITHDRAWAL_ADDRESS>
           Core withdrawal address (P2PKH / P2SH) [default: ]
       --amount <AMOUNT>
@@ -82,9 +84,10 @@ Register an Identity Name in the Dash Platform DPNS system
 Usage: platform-cli register-dpns-name [OPTIONS]
 
 Options:
+      --network <NETWORK>          Network, mainnet or testnet [default: ]
       --dapi-url <DAPI_URL>        DAPI GRPC Endpoint URL, ex. https://127.0.0.1:1443 [default: ]
       --identity <IDENTITY>        Identity address that registers a name [default: ]
-      --private-key <PRIVATE_KEY>  Identity private key in WIF format [default: ]
+      --private-key <PRIVATE_KEY>  Path to file with private key from Identity in WIF format [default: ]
       --name <NAME>                Name to register (excluding .dash) [default: ]
   -h, --help                       Print help
 ```
@@ -100,12 +103,14 @@ Perform a masternode vote towards contested DPNS name
 Usage: platform-cli masternode-vote-dpns-name [OPTIONS]
 
 Options:
+      --network <NETWORK>
+          Network, mainnet or testnet [default: ]
       --dapi-url <DAPI_URL>
           DAPI GRPC Endpoint URL, ex. https://127.0.0.1:1443 [default: ]
       --pro-tx-hash <PRO_TX_HASH>
           ProTxHash of the Masternode performing a Vote, in hex [default: ]
       --private-key <PRIVATE_KEY>
-          Voting (or Owner) private key in WIF format [default: ]
+          Path to file with voting (or owner) private key in WIF format [default: ]
       --normalized-label <NORMALIZED_LABEL>
           Normalized label to vote upon (can be grabbed from https//dash.vote) [default: ]
       --choice <CHOICE>

--- a/src/errors/cli_argument_invalid_input.rs
+++ b/src/errors/cli_argument_invalid_input.rs
@@ -1,0 +1,16 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub struct CommandLineArgumentInvalidInput(String);
+
+impl fmt::Display for CommandLineArgumentInvalidInput {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Input data is not valid: {}", &self.0)
+    }
+}
+
+impl From<&str> for CommandLineArgumentInvalidInput {
+    fn from(value: &str) -> Self {
+        CommandLineArgumentInvalidInput(String::from(value))
+    }
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Display, Formatter};
+use crate::errors::cli_argument_invalid_input::CommandLineArgumentInvalidInput;
 use crate::errors::cli_argument_missing_error::CommandLineArgumentMissingError;
 use crate::errors::dapi_response_error::DapiResponseError;
 use crate::errors::identity_not_found_error::{IdentityNotFoundError};
@@ -8,10 +9,12 @@ pub mod cli_argument_missing_error;
 pub mod identity_not_found_error;
 pub mod dapi_response_error;
 pub mod identity_public_key_hash_mismatch_error;
+pub mod cli_argument_invalid_input;
 
 
 pub enum Error {
     CommandLineArgumentMissingError(CommandLineArgumentMissingError),
+    CommandLineArgumentInvalidInput(CommandLineArgumentInvalidInput),
     IdentityNotFoundError(IdentityNotFoundError),
     IdentityPublicKeyHashMismatchError(IdentityPublicKeyHashMismatchError),
     DapiResponseError(DapiResponseError),
@@ -24,21 +27,15 @@ impl Display for Error {
                 write!(f, "{}", err)
             }
             Error::IdentityNotFoundError(err) => {
-                // match err{
-                //     IdentifierOrPublicKey::Identifier(identifier) => {
-                //         write!(f, "Identity with identifier {} not found.", identifier.to_string(Base58))
-                //     }
-                //     IdentifierOrPublicKey::PublicKey(pkh) => {
-                //         write!(f, "Identity by public key hash {} not found.", pkh)
-                //     }
-                // }
-                //
                 write!(f, "{}", err)
             }
             Error::DapiResponseError(err) => {
                 write!(f, "{}", err)
             }
             Error::IdentityPublicKeyHashMismatchError(err) => {
+                write!(f, "{}", err)
+            }
+            Error::CommandLineArgumentInvalidInput(err) => {
                 write!(f, "{}", err)
             }
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,11 @@
 use anyhow::Context;
+use base64::Engine;
+use base64::engine::general_purpose;
+use dpp::dashcore::{Network, PrivateKey};
 use dpp::util::entropy_generator::EntropyGenerator;
 use getrandom::getrandom;
+use crate::errors::cli_argument_invalid_input::CommandLineArgumentInvalidInput;
+use crate::errors::Error;
 
 
 pub struct MyDefaultEntropyGenerator;
@@ -10,5 +15,34 @@ impl EntropyGenerator for MyDefaultEntropyGenerator {
         let mut buffer = [0u8; 32];
         getrandom(&mut buffer).context("generating entropy failed").unwrap();
         Ok(buffer)
+    }
+}
+
+pub struct Utils;
+
+impl Utils {
+    pub fn decode_private_key_from_input_string(input: &str, network: Network) -> Result<PrivateKey, Error> {
+        let trimmed_input = input.replace("\n", "");
+
+        let base58: Vec<u8> = match PrivateKey::from_wif(&trimmed_input) {
+            Ok(private_key) => private_key.to_bytes(),
+            Err(_) => Vec::from([])
+        };
+        let hex: Vec<u8> = hex::decode(&trimmed_input).unwrap_or(Vec::from([]));
+        let base64: Vec<u8> = general_purpose::STANDARD.decode(hex::decode(&trimmed_input).unwrap_or(Vec::from([]))).unwrap_or(Vec::from([]));
+
+        let private_key: PrivateKey = {
+            if base58.len() > 0 {
+                PrivateKey::from_wif(&trimmed_input).expect("Unexpected error, could not construct private key from hex after validation")
+            } else if hex.len() > 0 {
+                PrivateKey::from_slice(hex.as_slice(), network).expect("Unexpected error, could not construct private key from hex after validation")
+            } else if base64.len() > 0 {
+                PrivateKey::from_slice(base64.as_slice(), network).expect("Unexpected error, could not construct private key from base64 after validation")
+            } else {
+                return Err(Error::CommandLineArgumentInvalidInput(CommandLineArgumentInvalidInput::from("Could not decode private key type from file (should be in WIF or hex)")))
+            }
+        };
+
+        Ok(private_key)
     }
 }


### PR DESCRIPTION
# Issue

We had only WIF encoding format for a private key, but user could have one in HEX encoded, and even Base64. It should be possible use any of them in the private key file transparently for the user.

# Things done

* Introduced new required command flag `network`
* Added a decoding function that tries to validate and load private key from any of known encoding types
* Corrected few flags documentation