### PR TITLE
Allow mainnet as a network type

### DIFF
--- a/src/commands/masternode_vote_dpns_name.rs
+++ b/src/commands/masternode_vote_dpns_name.rs
@@ -84,7 +84,8 @@ impl MasternodeVoteDPNSNameCommand {
 
         let secp = Secp256k1::new();
 
-        let network_type = Network::from_str(&self.network).expect("Could not parse network");
+        let network = if &self.network == "mainnet" { "dash" } else { &self.network  };
+        let network_type = Network::from_str(network).expect("Could not parse network");
         let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read private key file");
         let private_key = Utils::decode_private_key_from_input_string(private_key_data.as_str(), network_type)?;
         let public_key = private_key.public_key(&secp);

--- a/src/commands/register_dpns_name.rs
+++ b/src/commands/register_dpns_name.rs
@@ -101,7 +101,8 @@ impl RegisterDPNSNameCommand {
 
         let secp = Secp256k1::new();
 
-        let network_type = Network::from_str(&self.network).expect("Could not parse network");
+        let network = if &self.network == "mainnet" { "dash" } else { &self.network  };
+        let network_type = Network::from_str(network).expect("Could not parse network");
         let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read private key file");
         let private_key = Utils::decode_private_key_from_input_string(private_key_data.as_str(), network_type)?;
         let public_key = private_key.public_key(&secp);

--- a/src/commands/withdraw.rs
+++ b/src/commands/withdraw.rs
@@ -87,7 +87,8 @@ impl WithdrawCommand {
 
         let secp = Secp256k1::new();
 
-        let network_type = Network::from_str(&self.network).expect("Could not parse network");
+        let network = if &self.network == "mainnet" { "dash" } else { &self.network  };
+        let network_type = Network::from_str(network).expect("Could not parse network");
         let private_key_data = fs::read_to_string(&self.private_key).expect("Unable to read private key file");
         let private_key = Utils::decode_private_key_from_input_string(private_key_data.as_str(), network_type)?;
         let public_key = private_key.public_key(&secp);


### PR DESCRIPTION
# Issue

For some unknown reason, Dashcore's rust-dashcore Rust package accepts `dash` as a mainnet, but doesn't accept `mainnet` as a valid value for network. That leads to error when users trying to pass mainnet network to the --network flags

# Things done
* Added a check for mainnet value in the --network flag